### PR TITLE
refactor: pagination

### DIFF
--- a/docs/silidity/contracts/vault-viewer.md
+++ b/docs/silidity/contracts/vault-viewer.md
@@ -46,11 +46,11 @@ Holds information about members related to a vault:
 
 ### vaultAddressesBound
 
-Returns vault addresses for a range of vaults (indices are 1-based, inclusive)
+Returns vault addresses for a range of vaults
 
 ```solidity
-function vaultAddressesBound(uint256 _from, uint256 _to)
-view returns(IStakingVault[] memory vaults, uint256 leftover)
+function vaultAddressesBatch(uint256 _offset, uint256 _limit)
+view returns(IStakingVault[] memory vaults)
 ```
 
 ### vaultData
@@ -63,10 +63,10 @@ function vaultData(address vault) view returns(VaultData memory)
 
 ### vaultsDataBound
 
-Returns aggregated data for a range of vaults (indices are 1-based, inclusive)
+Returns aggregated data for a range of vaults
 
 ```solidity
-function vaultsDataBound(uint256 _from, uint256 _to)
+function vaultsDataBatch(uint256 _offset, uint256 _limit)
 view returns(VaultData[] memory vaultsData, uint256 leftover)
 ```
 
@@ -93,7 +93,7 @@ view returns(VaultMembers[] memory)
 Returns vaults owned by a specific address.
 
 ```solidity
-function vaultsByOwner(address _owner, uint256 _cursor, uint256 _limit) view returns(IStakingVault[] memory vaults, uint256 nextCursor)
+function vaultsByOwnerBatch(address _owner, uint256 _offset, uint256 _limit) view returns(IStakingVault[] memory vaults, uint256 nextCursor)
 ```
 
 <details>
@@ -101,7 +101,7 @@ function vaultsByOwner(address _owner, uint256 _cursor, uint256 _limit) view ret
 
 The **\_limit** parameter defines the maximum number of vaults to iterate over, not the number of owner matches to return.
 
-Each call scans up to **\_limit** positions in the global vault list starting from **\_cursor**, regardless of how many vaults belong to **\_owner**.
+Each call scans up to **\_limit** positions in the global vault list starting from **\_offset**, regardless of how many vaults belong to **\_owner**.
 This ensures predictable gas usage and prevents excessive iteration when the owner has no vaults (**\_ownerNoVaults** case).
 
 If the provided owner address has no connected vaults, the function still stops after **\_limit** iterations —
@@ -116,7 +116,7 @@ Continue paginating by calling again with **nextCursor** until it equals 0.
 Returns vaults where a member holds a specific role on the vault's owner contract.
 
 ```solidity
-function vaultsByRole(bytes32 _role, address _member, uint256 _cursor, uint256 _limit) view returns(IStakingVault[] memory vaults, uint256 nextCursor)
+function vaultsByRoleBatch(bytes32 _role, address _member, uint256 _offset, uint256 _limit) view returns(IStakingVault[] memory vaults, uint256 nextCursor)
 ```
 
 <details>
@@ -124,7 +124,7 @@ function vaultsByRole(bytes32 _role, address _member, uint256 _cursor, uint256 _
 
 The **\_limit** parameter specifies the maximum number of vaults to scan, not the number of matches where **\_member** has **\_role**.
 
-Each call examines up to **\_limit** vaults starting from **\_cursor**, regardless of how many contain the specified role.
+Each call examines up to **\_limit** vaults starting from **\_offset**, regardless of how many contain the specified role.
 This guarantees bounded gas cost and prevents full-list scans when the member has no assigned roles (**\_memberNoRoles** case).
 
 If the provided member address has no matching roles, the function still stops after **\_limit** iterations —

--- a/docs/silidity/deployed-contracts/hoodi.md
+++ b/docs/silidity/deployed-contracts/hoodi.md
@@ -10,7 +10,7 @@ Hoodi is the main operational and maintained protocol testnet.
 
 ## Contracts
 
-- Vault Viewer: [`0xd1d1ce64d894a78833F940026C5c7893301C0Ae4`](https://hoodi.etherscan.io/address/0xd1d1ce64d894a78833F940026C5c7893301C0Ae4)
+- Vault Viewer: [`0xBa9a3127f053a6548FE3874326569E1821783e03`](https://hoodi.etherscan.io/address/0xBa9a3127f053a6548FE3874326569E1821783e03)
 
   <a href="/si-lidity/abi/VaultViewer.json" download>📥 Download ABI</a>
 

--- a/docs/silidity/deployed-contracts/hoodi.md
+++ b/docs/silidity/deployed-contracts/hoodi.md
@@ -10,7 +10,7 @@ Hoodi is the main operational and maintained protocol testnet.
 
 ## Contracts
 
-- Vault Viewer: [`0x3194B50c26108438Cfc9A916A24Ba8aAB9C17CAB`](https://hoodi.etherscan.io/address/0x3194B50c26108438Cfc9A916A24Ba8aAB9C17CAB)
+- Vault Viewer: [`0xd1d1ce64d894a78833F940026C5c7893301C0Ae4`](https://hoodi.etherscan.io/address/0xd1d1ce64d894a78833F940026C5c7893301C0Ae4)
 
   <a href="/si-lidity/abi/VaultViewer.json" download>📥 Download ABI</a>
 

--- a/docs/static/abi/VaultViewer.json
+++ b/docs/static/abi/VaultViewer.json
@@ -13,22 +13,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_cursor",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "vaultsCount",
-        "type": "uint256"
-      }
-    ],
-    "name": "WrongCursorPagination",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "string",
         "name": "argName",
         "type": "string"

--- a/docs/static/abi/VaultViewer.json
+++ b/docs/static/abi/VaultViewer.json
@@ -29,22 +29,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_from",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_to",
-        "type": "uint256"
-      }
-    ],
-    "name": "WrongPaginationRange",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "string",
         "name": "argName",
         "type": "string"
@@ -273,26 +257,21 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "_from",
+        "name": "_offset",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "_to",
+        "name": "_limit",
         "type": "uint256"
       }
     ],
-    "name": "vaultAddressesBound",
+    "name": "vaultAddressesBatch",
     "outputs": [
       {
         "internalType": "contract IStakingVault[]",
         "name": "vaults",
         "type": "address[]"
-      },
-      {
-        "internalType": "uint256",
-        "name": "leftover",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -523,7 +502,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "_cursor",
+        "name": "_offset",
         "type": "uint256"
       },
       {
@@ -532,17 +511,12 @@
         "type": "uint256"
       }
     ],
-    "name": "vaultsByOwner",
+    "name": "vaultsByOwnerBatch",
     "outputs": [
       {
         "internalType": "contract IStakingVault[]",
         "name": "vaults",
         "type": "address[]"
-      },
-      {
-        "internalType": "uint256",
-        "name": "nextCursor",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -562,7 +536,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "_cursor",
+        "name": "_offset",
         "type": "uint256"
       },
       {
@@ -571,16 +545,24 @@
         "type": "uint256"
       }
     ],
-    "name": "vaultsByRole",
+    "name": "vaultsByRoleBatch",
     "outputs": [
       {
         "internalType": "contract IStakingVault[]",
         "name": "vaults",
         "type": "address[]"
-      },
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vaultsCount",
+    "outputs": [
       {
         "internalType": "uint256",
-        "name": "nextCursor",
+        "name": "",
         "type": "uint256"
       }
     ],
@@ -591,16 +573,16 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "_from",
+        "name": "_offset",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "_to",
+        "name": "_limit",
         "type": "uint256"
       }
     ],
-    "name": "vaultsDataBound",
+    "name": "vaultsDataBatch",
     "outputs": [
       {
         "components": [
@@ -803,11 +785,6 @@
         "internalType": "struct VaultViewer.VaultData[]",
         "name": "vaultsData",
         "type": "tuple[]"
-      },
-      {
-        "internalType": "uint256",
-        "name": "leftover",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -220,7 +220,7 @@ contract VaultViewer {
     /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
     /// @param _limit Maximum number of vaults to return (must be > 0)
     /// @return vaultsData Array of aggregated vault data (length <= _limit)
-    function vaultsDataBound(uint256 _offset, uint256 _limit) external view returns (VaultData[] memory vaultsData) {
+    function vaultsDataBatch(uint256 _offset, uint256 _limit) external view returns (VaultData[] memory vaultsData) {
         _requireNotZero(_limit, '_limit');
 
         VaultHub vaultHub = VAULT_HUB;
@@ -245,7 +245,7 @@ contract VaultViewer {
     /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
     /// @param _limit Maximum number of vaults to return (must be > 0)
     /// @return vaults Array of vault contracts (IStakingVault)
-    function vaultAddressesBound(uint256 _offset, uint256 _limit) public view returns (IStakingVault[] memory vaults) {
+    function vaultAddressesBatch(uint256 _offset, uint256 _limit) public view returns (IStakingVault[] memory vaults) {
         _requireNotZero(_limit, '_limit');
 
         VaultHub vaultHub = VAULT_HUB;

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -245,7 +245,6 @@ contract VaultViewer {
     /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
     /// @param _limit Maximum number of vaults to return (must be > 0)
     /// @return vaults Array of vault contracts (IStakingVault)
-    /// @custom:todo vaultAddressesBound --> vaultAddressesBatch
     function vaultAddressesBound(uint256 _offset, uint256 _limit) public view returns (IStakingVault[] memory vaults) {
         _requireNotZero(_limit, '_limit');
 

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -384,9 +384,4 @@ contract VaultViewer {
     /// @notice Error for zero address arguments
     /// @param argName Name of the argument that is zero
     error ZeroArgument(string argName);
-
-    /// @notice Error for wrong cursor in the pagination
-    /// @param _cursor The 1-based cursor value provided by the caller
-    /// @param vaultsCount The total number of vaults available for pagination
-    error WrongCursorPagination(uint256 _cursor, uint256 vaultsCount);
 }

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -93,51 +93,47 @@ contract VaultViewer {
         return _checkHasRole(connection.owner, _member, _role);
     }
 
-    /// @notice Returns vaults owned by `_owner` using `cursor-based` pagination
+    /// @notice Returns vaults owned by `_owner` using batch pagination over the global vault list
     /// @param _owner Address of the owner
-    /// @param _cursor 1-based global index to start from (pass 1 to start from the first vault)
-    /// @param _limit Maximum number of vaults to iterate over (must be > 0)
-    /// @return vaults Array of owner-matching vaults (max length <= _limit)
-    /// @return nextCursor 1-based index to resume from, or 0 if end is reached
-    function vaultsByOwner(
+    /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
+    /// @param _limit Maximum number of vaults to SCAN (must be > 0)
+    /// @return vaults Array of owner-matching vaults found within the scanned window (length <= _limit)
+    function vaultsByOwnerBatch(
         address _owner,
-        uint256 _cursor,
+        uint256 _offset,
         uint256 _limit
-    ) public view returns (IStakingVault[] memory vaults, uint256 nextCursor) {
-        // VaultHub index is 1-based
-        _requireNotZero(_cursor, '_cursor');
-        _requireNotZero(_limit, '_limit');
+    ) public view returns (IStakingVault[] memory vaults) {
+        _requireNotZero(_limit, "_limit");
 
         VaultHub vaultHub = VAULT_HUB;
         uint256 vaultsCount = vaultHub.vaultsCount();
-        if (_cursor > vaultsCount) revert WrongCursorPagination(_cursor, vaultsCount);
 
-        uint256 remaining = vaultsCount - _cursor + 1;
-        uint256 scan = _limit < remaining ? _limit : remaining;
+        if (_offset >= vaultsCount) {
+            return new IStakingVault[](0);
+        }
 
-        if (scan == 0) return (new IStakingVault[](0), 0);
+        uint256 scanSize = _offset + _limit > vaultsCount ? vaultsCount - _offset : _limit;
 
-        vaults = new IStakingVault[](scan);
+        vaults = new IStakingVault[](scanSize);
         IStakingVault vault;
         uint256 matchedCount = 0;
 
-        uint256 end = _cursor + scan;
-        uint256 i = _cursor;
+        uint256 end = _offset + scanSize;
+        uint256 i = _offset;
         for (; i < end; ) {
-            vault = IStakingVault(vaultHub.vaultByIndex(i));
+            // vaultByIndex is 1-based, _offset is 0-based → add +1
+            vault = IStakingVault(vaultHub.vaultByIndex(i + 1));
             if (isVaultOwner(vault, _owner)) {
                 vaults[matchedCount] = vault;
-                unchecked { ++matchedCount; }
+            unchecked { ++matchedCount; }
             }
-            unchecked { ++i; }
+        unchecked { ++i; }
         }
 
         // shrink to actual length
         assembly { mstore(vaults, matchedCount) }
-
-        // next cursor (0 means end)
-        nextCursor = (scan == remaining) ? 0 : (_cursor + scan);
     }
+
 
     /// @notice Returns vaults where `_member` has `_role`, using cursor-based pagination
     /// @param _role Role to check

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -220,7 +220,7 @@ contract VaultViewer {
     /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
     /// @param _limit Maximum number of vaults to return (must be > 0)
     /// @return vaultsData Array of aggregated vault data (length <= _limit)
-    /// @todo: vaultsDataBound --> vaultsDataBatch
+    /// @custom:todo vaultsDataBound --> vaultsDataBatch
     function vaultsDataBound(uint256 _offset, uint256 _limit) external view returns (VaultData[] memory vaultsData) {
         _requireNotZero(_limit, '_limit');
 
@@ -246,7 +246,7 @@ contract VaultViewer {
     /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
     /// @param _limit Maximum number of vaults to return (must be > 0)
     /// @return vaults Array of vault contracts (IStakingVault)
-    /// @todo: vaultAddressesBound --> vaultAddressesBatch
+    /// @custom:todo vaultAddressesBound --> vaultAddressesBatch
     function vaultAddressesBound(uint256 _offset, uint256 _limit) public view returns (IStakingVault[] memory vaults) {
         _requireNotZero(_limit, '_limit');
 

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -188,6 +188,12 @@ contract VaultViewer {
         nextCursor = (scan == remaining) ? 0 : (_cursor + scan);
     }
 
+    /// @notice returns the number of vaults connected to the VaultHub
+    /// @return the number of vaults connected to the VaultHub
+    function vaultsCount() external view returns (uint256) {
+        return VAULT_HUB.vaultsCount();
+    }
+
     /// @notice Returns aggregated data for a single vault
     /// @param vault Address of the vault
     /// @return data Aggregated vault data
@@ -210,73 +216,56 @@ contract VaultViewer {
         });
     }
 
-    /// @notice Returns aggregated data for a range of vaults (indices are 1-based, inclusive)
-    /// @param _from 1-based index to start from (inclusive)
-    /// @param _to 1-based index to end at (inclusive)
-    /// @return vaultsData Array of aggregated vault data
-    /// @return leftover Number of leftover vaults
-    function vaultsDataBound(
-        uint256 _from,
-        uint256 _to
-    ) external view returns (VaultData[] memory vaultsData, uint256 leftover) {
-        // VaultHub index is 1-based
-        _requireNotZero(_from, '_from');
-        _requireNotZero(_to, '_to');
-
-        if (_from > _to) revert WrongPaginationRange(_from, _to);
+    /// @notice Returns aggregated data for a batch of vaults
+    /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
+    /// @param _limit Maximum number of vaults to return (must be > 0)
+    /// @return vaultsData Array of aggregated vault data (length <= _limit)
+    /// @todo: vaultsDataBound --> vaultsDataBatch
+    function vaultsDataBound(uint256 _offset, uint256 _limit) external view returns (VaultData[] memory vaultsData) {
+        _requireNotZero(_limit, '_limit');
 
         VaultHub vaultHub = VAULT_HUB;
         uint256 vaultsCount = vaultHub.vaultsCount();
-
-        if (_to > vaultsCount) {
-            _to = vaultsCount;
+        uint256 batchSize;
+        if (_offset >= vaultsCount) {
+            batchSize = 0;
+        } else {
+            batchSize = _offset + _limit > vaultsCount ? vaultsCount - _offset : _limit;
         }
 
-        if (_from > vaultsCount) revert WrongPaginationRange(_from, _to);
-
-        uint256 outputCount = _to >= _from ? (_to - _from + 1) : 0;
-        vaultsData = new VaultData[](outputCount);
-
-        for (uint256 i = 0; i < outputCount; ) {
-            address va = vaultHub.vaultByIndex(_from + i);
-            vaultsData[i] = vaultData(va);
-            unchecked { ++i; }
-        }
-
-        leftover = vaultsCount > _to ? vaultsCount - _to : 0;
-    }
-
-    /// @notice Returns vault addresses for a range of vaults (indices are 1-based, inclusive)
-    /// @param _from 1-based index to start from (inclusive)
-    /// @param _to 1-based index to end at (inclusive)
-    /// @return vaults Array of vault contracts (IStakingVault)
-    /// @return leftover Number of leftover vaults
-    function vaultAddressesBound(uint256 _from, uint256 _to) public view returns (IStakingVault[] memory vaults, uint256 leftover) {
-        // VaultHub index is 1-based
-        _requireNotZero(_from, '_from');
-        _requireNotZero(_to, '_to');
-
-        if (_from > _to) revert WrongPaginationRange(_from, _to);
-
-        VaultHub vaultHub = VAULT_HUB;
-        uint256 vaultsCount = vaultHub.vaultsCount();
-
-        if (_to > vaultsCount) {
-            _to = vaultsCount;
-        }
-
-        if (_from > vaultsCount) revert WrongPaginationRange(_from, _to);
-
-        uint256 outputCount = _to >= _from ? (_to - _from + 1) : 0;
-        vaults = new IStakingVault[](outputCount);
-
-        for (uint256 i = 0; i < outputCount; ) {
-            address vault = vaultHub.vaultByIndex(_from + i);
-            vaults[i] = IStakingVault(vault);
+        vaultsData = new VaultData[](batchSize);
+        for (uint256 i = 0; i < batchSize; ) {
+            // vaultByIndex is 1-based, _offset is 0-based → add +1
+            address vaultAddress = vaultHub.vaultByIndex(_offset + i + 1);
+            vaultsData[i] = vaultData(vaultAddress);
         unchecked { ++i; }
         }
+    }
 
-        leftover = vaultsCount > _to ? vaultsCount - _to : 0;
+    /// @notice Returns vault addresses for a range of vaults
+    /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
+    /// @param _limit Maximum number of vaults to return (must be > 0)
+    /// @return vaults Array of vault contracts (IStakingVault)
+    /// @todo: vaultAddressesBound --> vaultAddressesBatch
+    function vaultAddressesBound(uint256 _offset, uint256 _limit) public view returns (IStakingVault[] memory vaults) {
+        _requireNotZero(_limit, '_limit');
+
+        VaultHub vaultHub = VAULT_HUB;
+        uint256 vaultsCount = vaultHub.vaultsCount();
+        uint256 outputCount;
+        if (_offset >= vaultsCount) {
+            outputCount = 0;
+        } else {
+            outputCount = _offset + _limit > vaultsCount ? vaultsCount - _offset : _limit;
+        }
+
+        vaults = new IStakingVault[](outputCount);
+        for (uint256 i = 0; i < outputCount; ) {
+            // vaultByIndex is 1-based, _offset is 0-based → add +1
+            address vaultAddress = vaultHub.vaultByIndex(_offset + i + 1);
+            vaults[i] = IStakingVault(vaultAddress);
+        unchecked { ++i; }
+        }
     }
 
     /// @notice Returns the VaultMembers for each specified role on a single vault
@@ -408,11 +397,6 @@ contract VaultViewer {
     /// @notice Error for zero address arguments
     /// @param argName Name of the argument that is zero
     error ZeroArgument(string argName);
-
-    /// @notice Error for wrong pagination range
-    /// @param _from Start of the range
-    /// @param _to End of the range
-    error WrongPaginationRange(uint256 _from, uint256 _to);
 
     /// @notice Error for wrong cursor in the pagination
     /// @param _cursor The 1-based cursor value provided by the caller

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -214,12 +214,12 @@ contract VaultViewer {
 
         VaultHub vaultHub = VAULT_HUB;
         uint256 vaultsCount = vaultHub.vaultsCount();
-        uint256 batchSize;
+
         if (_offset >= vaultsCount) {
-            batchSize = 0;
-        } else {
-            batchSize = _offset + _limit > vaultsCount ? vaultsCount - _offset : _limit;
+            return new VaultData[](0);
         }
+
+        uint256 batchSize = _offset + _limit > vaultsCount ? vaultsCount - _offset : _limit;
 
         vaultsData = new VaultData[](batchSize);
         for (uint256 i = 0; i < batchSize; ) {
@@ -239,15 +239,15 @@ contract VaultViewer {
 
         VaultHub vaultHub = VAULT_HUB;
         uint256 vaultsCount = vaultHub.vaultsCount();
-        uint256 outputCount;
+
         if (_offset >= vaultsCount) {
-            outputCount = 0;
-        } else {
-            outputCount = _offset + _limit > vaultsCount ? vaultsCount - _offset : _limit;
+            return new IStakingVault[](0);
         }
 
-        vaults = new IStakingVault[](outputCount);
-        for (uint256 i = 0; i < outputCount; ) {
+        uint256 batchSize = _offset + _limit > vaultsCount ? vaultsCount - _offset : _limit;
+
+        vaults = new IStakingVault[](batchSize);
+        for (uint256 i = 0; i < batchSize; ) {
             // vaultByIndex is 1-based, _offset is 0-based → add +1
             address vaultAddress = vaultHub.vaultByIndex(_offset + i + 1);
             vaults[i] = IStakingVault(vaultAddress);

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -220,7 +220,6 @@ contract VaultViewer {
     /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
     /// @param _limit Maximum number of vaults to return (must be > 0)
     /// @return vaultsData Array of aggregated vault data (length <= _limit)
-    /// @custom:todo vaultsDataBound --> vaultsDataBatch
     function vaultsDataBound(uint256 _offset, uint256 _limit) external view returns (VaultData[] memory vaultsData) {
         _requireNotZero(_limit, '_limit');
 

--- a/si-contracts/0.8.25/vaults/VaultViewer.sol
+++ b/si-contracts/0.8.25/vaults/VaultViewer.sol
@@ -134,54 +134,47 @@ contract VaultViewer {
         assembly { mstore(vaults, matchedCount) }
     }
 
-
-    /// @notice Returns vaults where `_member` has `_role`, using cursor-based pagination
+    /// @notice Returns vaults where `_member` has `_role`, scanning a batch of the global vault list
     /// @param _role Role to check
     /// @param _member Address to check for the role
-    /// @param _cursor 1-based global index to start from (pass 1 to start from the first vault)
-    /// @param _limit Maximum number of vaults to iterate over (must be > 0)
-    /// @return vaults Array of vaults where `_member` has `_role` (max length ≤ _limit)
-    /// @return nextCursor 1-based index to resume from, or 0 if end is reached
-    function vaultsByRole(
+    /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
+    /// @param _limit Maximum number of vaults to SCAN (must be > 0)
+    /// @return vaults Array of vaults where `_member` has `_role` found within the scanned window (length ≤ _limit)
+    function vaultsByRoleBatch(
         bytes32 _role,
         address _member,
-        uint256 _cursor,
+        uint256 _offset,
         uint256 _limit
-    ) public view returns (IStakingVault[] memory vaults, uint256 nextCursor) {
-        // VaultHub index is 1-based
-        _requireNotZero(_cursor, '_cursor');
-        _requireNotZero(_limit, '_limit');
+    ) public view returns (IStakingVault[] memory vaults) {
+        _requireNotZero(_limit, "_limit");
 
         VaultHub vaultHub = VAULT_HUB;
         uint256 vaultsCount = vaultHub.vaultsCount();
 
-        if (_cursor > vaultsCount) revert WrongCursorPagination(_cursor, vaultsCount);
+        if (_offset >= vaultsCount) {
+            return new IStakingVault[](0);
+        }
 
-        uint256 remaining = vaultsCount - _cursor + 1;
-        uint256 scan = _limit < remaining ? _limit : remaining;
+        uint256 scanSize = _offset + _limit > vaultsCount ? vaultsCount - _offset : _limit;
 
-        if (scan == 0) return (new IStakingVault[](0), 0);
-
-        vaults = new IStakingVault[](scan);
+        vaults = new IStakingVault[](scanSize);
         IStakingVault vault;
         uint256 matchedCount = 0;
 
-        uint256 end = _cursor + scan;
-        uint256 i = _cursor;
+        uint256 end = _offset + scanSize;
+        uint256 i = _offset;
         for (; i < end; ) {
-            vault = IStakingVault(vaultHub.vaultByIndex(i));
+            // vaultByIndex is 1-based, _offset is 0-based → add +1
+            vault = IStakingVault(vaultHub.vaultByIndex(i + 1));
             if (hasRole(vault, _member, _role)) {
                 vaults[matchedCount] = vault;
-                unchecked { ++matchedCount; }
+            unchecked { ++matchedCount; }
             }
-            unchecked { ++i; }
+        unchecked { ++i; }
         }
 
         // shrink to actual number of matches
         assembly { mstore(vaults, matchedCount) }
-
-        // next cursor (0 means end)
-        nextCursor = (scan == remaining) ? 0 : (_cursor + scan);
     }
 
     /// @notice returns the number of vaults connected to the VaultHub

--- a/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
+++ b/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
@@ -255,58 +255,64 @@ describe("VaultViewer", () => {
       }
     });
 
-    // [
-    //   { from: 1, to: 1 },
-    //   { from: 1, to: 2 },
-    //   { from: 2, to: 3 },
-    //   { from: 1, to: stakingVaultCount },
-    //   { from: 3, to: stakingVaultCount },
-    //   { from: stakingVaultCount, to: stakingVaultCount },
-    //   { from: 1, to: stakingVaultCount }, // All
-    //   { from: 1, to: stakingVaultCount + 1 }, // more that all
-    //   { from: 1, to: stakingVaultCount + stakingVaultCount }, // more that all
-    // ].forEach(({ from, to }) => {
-    //   it(`returns vault contracts in a given range [${from}, ${to}]`, async () => {
-    //     const [vaults, leftover] = await vaultViewer.vaultAddressesBound(from, to);
-    //
-    //     const safeTo = Math.min(to, stakingVaultCount);
-    //     const expectedLength = from > safeTo ? 0 : safeTo - from + 1;
-    //     expect(vaults.length).to.equal(expectedLength);
-    //
-    //     const expectedLeftover = Math.max(0, stakingVaultCount - safeTo);
-    //     expect(leftover).to.equal(expectedLeftover);
-    //   });
-    // });
+    [
+      { offset: 0, limit: 1 },
+      { offset: 0, limit: 2 },
+      { offset: 1, limit: 2 },
+      // all
+      { offset: 0, limit: stakingVaultCount },
+      { offset: 2, limit: stakingVaultCount },
+      // only last
+      { offset: stakingVaultCount - 1, limit: stakingVaultCount },
+      { offset: 0, limit: stakingVaultCount + 1 },
+      { offset: 0, limit: stakingVaultCount * 2 },
+      // empty
+      { offset: stakingVaultCount, limit: 10 },
+      // empty
+      { offset: stakingVaultCount + 5, limit: 10 },
+    ].forEach(({ offset, limit }) => {
+      it(`returns vault contracts for (offset=${offset}, limit=${limit})`, async () => {
+        const total = stakingVaultCount;
+        const expectedLength = offset >= total ? 0 : Math.min(limit, total - offset);
 
-    // [
-    //   { from: 1_000, to: 10_000 },
-    //   { from: 3, to: 1 },
-    //   { from: stakingVaultCount, to: 1 },
-    //   { from: stakingVaultCount * 10, to: stakingVaultCount * 10 },
-    //   { from: stakingVaultCount * 10, to: stakingVaultCount * 100 },
-    //   { from: stakingVaultCount * 100, to: stakingVaultCount },
-    // ].forEach(({ from, to }) => {
-    //   it(`reverts if given range is invalid [${from}, ${to}]`, async () => {
-    //     await expect(vaultViewer.vaultAddressesBound(from, to)).to.be.revertedWithCustomError(
-    //       vaultViewer,
-    //       "WrongPaginationRange",
-    //     );
-    //   });
-    // });
+        const vaults = await vaultViewer.vaultAddressesBound(offset, limit);
+        expect(vaults.length).to.equal(expectedLength);
 
-    //   [
-    //     { from: 0, to: 0 },
-    //     { from: 0, to: 1 },
-    //     { from: 0, to: 2 },
-    //     { from: stakingVaultCount, to: 0 },
-    //   ].forEach(({ from, to }) => {
-    //     it(`reverts with ZeroArgument for invalid range [${from}, ${to}]`, async () => {
-    //       await expect(vaultViewer.vaultAddressesBound(from, to)).to.be.revertedWithCustomError(
-    //         vaultViewer,
-    //         "ZeroArgument",
-    //       );
-    //     });
-    //   });
+        for (let i = 0; i < vaults.length; i++) {
+          const expectedAddr = await stakingVaults[offset + i].stakingVault.getAddress();
+          expect(vaults[i]).to.equal(expectedAddr);
+        }
+      });
+    });
+
+    [
+      { offset: stakingVaultCount, limit: 1 },
+      { offset: stakingVaultCount * 10, limit: 5 },
+      { offset: stakingVaultCount * 100, limit: stakingVaultCount },
+      { offset: stakingVaultCount + 1, limit: stakingVaultCount * 10 },
+      { offset: stakingVaultCount * 10, limit: stakingVaultCount * 10 },
+      { offset: stakingVaultCount * 100, limit: stakingVaultCount * 10 },
+      { offset: stakingVaultCount * 10, limit: stakingVaultCount * 100 },
+    ].forEach(({ offset, limit }) => {
+      it(`returns empty for out-of-range (offset=${offset}, limit=${limit})`, async () => {
+        const vaults = await vaultViewer.vaultAddressesBound(offset, limit);
+        expect(vaults.length).to.equal(0);
+      });
+    });
+
+    [
+      { offset: 0, limit: 0 },
+      { offset: 1, limit: 0 },
+      { offset: stakingVaultCount, limit: 0 },
+      { offset: stakingVaultCount * 10, limit: 0 },
+    ].forEach(({ offset, limit }) => {
+      it(`reverts with ZeroArgument when limit is zero (offset=${offset}, limit=${limit})`, async () => {
+        await expect(vaultViewer.vaultAddressesBound(offset, limit)).to.be.revertedWithCustomError(
+          vaultViewer,
+          "ZeroArgument",
+        );
+      });
+    });
   });
 
   context("vaults by owner", () => {
@@ -883,6 +889,9 @@ describe("VaultViewer", () => {
     });
 
     [
+      { offset: stakingVaultCount, limit: 1 },
+      { offset: stakingVaultCount * 10, limit: 5 },
+      { offset: stakingVaultCount * 100, limit: stakingVaultCount },
       { offset: stakingVaultCount + 1, limit: stakingVaultCount * 10 },
       { offset: stakingVaultCount * 10, limit: stakingVaultCount * 10 },
       { offset: stakingVaultCount * 100, limit: stakingVaultCount * 10 },

--- a/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
+++ b/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
@@ -339,85 +339,106 @@ describe("VaultViewer", () => {
 
     ownersTestCases.forEach(({ label, getOwner }) => {
       [
-        { cursor: 1, limit: 1 },
-        { cursor: 1, limit: 2 },
-        { cursor: 3, limit: 6 },
-        { cursor: vaultSplitIndex, limit: vaultSplitIndex },
-        { cursor: 1, limit: vaultSplitIndex },
-      ].forEach(({ cursor, limit }) => {
-        it(`returns all vaults owned by a given address ${label} where cursor=${cursor}, limit=${limit}`, async () => {
+        { offset: 0, limit: 1 },
+        { offset: 0, limit: 2 },
+        { offset: 2, limit: 6 },
+        { offset: 0, limit: vaultSplitIndex },
+        { offset: 1, limit: vaultSplitIndex },
+        { offset: vaultSplitIndex - 1, limit: vaultSplitIndex },
+      ].forEach(({ offset, limit }) => {
+        it(`returns owner-matching vaults (batched) for ${label} with offset=${offset}, limit=${limit}`, async () => {
           const owner = getOwner();
-          const [vaults, nextCursor] = await vaultViewer.vaultsByOwner(owner, cursor, limit);
+          const vaults = await vaultViewer.vaultsByOwnerBatch(owner, offset, limit);
 
           const total = stakingVaults.length;
-          const remaining = total - cursor + 1;
-          const maxScan = Math.min(limit, Math.max(remaining, 0));
+          const remaining = Math.max(0, total - offset);
+          const maxScan = Math.min(limit, remaining);
 
           const expectedVaults: string[] = [];
-          for (let gi = cursor; gi <= total && gi < cursor + maxScan; gi++) {
-            // vaultHub uses 1-based indexing, but stakingVaults is a regular 0-based JS array.
-            const idx = gi - 1;
-            const { stakingVault } = stakingVaults[idx];
-            const ownerAtGi = idx < vaultSplitIndex ? firstBatchOwner : secondBatchOwner;
+          for (let gi = offset; gi < offset + maxScan && gi < total; gi++) {
+            const { stakingVault } = stakingVaults[gi];
+            const ownerAtGi = gi < vaultSplitIndex ? firstBatchOwner : secondBatchOwner;
             if (ownerAtGi.address === owner.address) {
               expectedVaults.push(await stakingVault.getAddress());
             }
           }
 
-          // ✅ Check vaults
+          // ✅ Address ordering check
           expect(vaults.length).to.equal(expectedVaults.length);
           for (let i = 0; i < expectedVaults.length; i++) {
             expect(vaults[i]).to.equal(expectedVaults[i]);
           }
+        });
+      });
+    });
 
-          // ✅ Check nextCursor
-          const expectedNextCursor = cursor + maxScan <= total ? BigInt(cursor + maxScan) : 0;
-          expect(nextCursor).to.equal(expectedNextCursor);
+    ownersTestCases.forEach(({ label, getOwner }) => {
+      [
+        { offset: 0, limit: 1 },
+        { offset: 0, limit: 2 },
+        { offset: 2, limit: 6 },
+        { offset: vaultSplitIndex - 1, limit: vaultSplitIndex },
+        { offset: 0, limit: vaultSplitIndex },
+        { offset: 0, limit: vaultSplitIndex * 10 },
+      ].forEach(({ offset, limit }) => {
+        it(`returns all vaults owned by a given address ${label} where offset=${offset}, limit=${limit}`, async () => {
+          const owner = getOwner();
+          const vaults = await vaultViewer.vaultsByOwnerBatch(owner, offset, limit);
+
+          const total = stakingVaults.length;
+          const remaining = Math.max(total - offset, 0);
+          const maxScan = Math.min(limit, remaining);
+
+          const expectedVaults: string[] = [];
+          for (let gi = offset; gi < offset + maxScan && gi < total; gi++) {
+            const { stakingVault } = stakingVaults[gi];
+            const ownerAtGi = gi < vaultSplitIndex ? firstBatchOwner : secondBatchOwner;
+            if (ownerAtGi.address === owner.address) {
+              expectedVaults.push(await stakingVault.getAddress());
+            }
+          }
+
+          // ✅ Address ordering check
+          expect(vaults.length).to.equal(expectedVaults.length);
+          for (let i = 0; i < expectedVaults.length; i++) {
+            expect(vaults[i]).to.equal(expectedVaults[i]);
+          }
         });
       });
     });
 
     [
-      { cursor: 1, limit: 1 },
-      { cursor: 1, limit: 2 },
-      { cursor: 1, limit: vaultSplitIndex },
-      { cursor: 1, limit: vaultSplitIndex * 10 },
-    ].forEach(({ cursor, limit }) => {
-      it(`returns zero vaults owned by a given address (ownerWithNoVaults) where cursor=${cursor}, limit=${limit}`, async () => {
-        const [vaults, nextCursor] = await vaultViewer.vaultsByOwner(ownerWithNoVaults, cursor, limit);
-
-        const total = stakingVaults.length;
-        const remaining = total - cursor + 1;
-        const maxScan = Math.min(limit, Math.max(remaining, 0));
+      { offset: 0, limit: 1 },
+      { offset: 0, limit: 2 },
+      { offset: 0, limit: vaultSplitIndex },
+      { offset: 0, limit: vaultSplitIndex * 10 },
+    ].forEach(({ offset, limit }) => {
+      it(`returns zero vaults for ownerWithNoVaults (offset=${offset}, limit=${limit})`, async () => {
+        const vaults = await vaultViewer.vaultsByOwnerBatch(ownerWithNoVaults, offset, limit);
 
         // ✅ Check vaults
+        expect(Array.isArray(vaults)).to.equal(true);
         expect(vaults.length).to.equal(0);
-
-        // ✅ Check nextCursor
-        const expectedNextCursor = cursor + maxScan <= total ? BigInt(cursor + maxScan) : 0n;
-        expect(nextCursor).to.equal(expectedNextCursor);
       });
     });
 
     [
-      { cursor: stakingVaultCount + 1, limit: 2 },
-      { cursor: stakingVaultCount * 10, limit: stakingVaultCount * 10 },
-    ].forEach(({ cursor, limit }) => {
-      it(`reverts with WrongCursorPagination where cursor=${cursor}, limit=${limit}`, async () => {
-        await expect(vaultViewer.vaultsByOwner(secondBatchOwner, cursor, limit)).to.be.revertedWithCustomError(
-          vaultViewer,
-          "WrongCursorPagination",
-        );
+      { offset: stakingVaultCount, limit: 2 },
+      { offset: stakingVaultCount * 10, limit: stakingVaultCount * 10 },
+    ].forEach(({ offset, limit }) => {
+      it(`returns empty array when offset is out of bounds (offset=${offset}, limit=${limit})`, async () => {
+        const vaults = await vaultViewer.vaultsByOwnerBatch(secondBatchOwner, offset, limit);
+        expect(vaults.length).to.equal(0);
       });
     });
 
     [
-      { cursor: 0, limit: 0 },
-      { cursor: 0, limit: 2 },
-      { cursor: 2, limit: 0 },
-    ].forEach(({ cursor, limit }) => {
-      it(`reverts with ZeroArgument where cursor=${cursor}, limit=${limit}`, async () => {
-        await expect(vaultViewer.vaultsByOwner(secondBatchOwner, cursor, limit)).to.be.revertedWithCustomError(
+      { offset: 0, limit: 0 },
+      { offset: 5, limit: 0 },
+      { offset: stakingVaultCount, limit: 0 },
+    ].forEach(({ offset, limit }) => {
+      it(`reverts with ZeroArgument when limit == 0 (offset=${offset}, limit=${limit})`, async () => {
+        await expect(vaultViewer.vaultsByOwnerBatch(secondBatchOwner, offset, limit)).to.be.revertedWithCustomError(
           vaultViewer,
           "ZeroArgument",
         );
@@ -426,27 +447,27 @@ describe("VaultViewer", () => {
 
     ownersTestCases.forEach(({ label, getOwner }) => {
       [
-        { cursor: 1, limit: 1 },
-        { cursor: 1, limit: 2 },
-        { cursor: 1, limit: 3 },
-        { cursor: 1, limit: stakingVaultCount },
-      ].forEach(({ cursor, limit }) => {
-        it(`walks all pages(cursor=${cursor}, limit=${limit}) for ${label} via nextCursor and returns exactly his vaults in order`, async () => {
+        { offset: 0, limit: 1 },
+        { offset: 0, limit: 2 },
+        { offset: 0, limit: 3 },
+        { offset: 0, limit: stakingVaultCount },
+        { offset: 0, limit: stakingVaultCount * 2 },
+      ].forEach(({ offset, limit }) => {
+        it(`walks all pages(offset=${offset}, limit=${limit}) for ${label} and returns exactly his vaults in order`, async () => {
           const maxIters = 100;
           const collected: string[] = [];
-
           const owner = getOwner();
 
-          for (let i = 0; i < maxIters; i++) {
-            const [page, nextCursor] = await vaultViewer.vaultsByOwner(owner, cursor, limit);
+          const total = stakingVaults.length;
+          let curOffset = offset;
+          for (let i = 0; i < maxIters && curOffset < total; i++) {
+            const page: string[] = await vaultViewer.vaultsByOwnerBatch(owner, curOffset, limit);
             collected.push(...page);
-
-            if (nextCursor === 0n) break;
-            cursor = Number(nextCursor);
+            curOffset += limit;
           }
 
           const expected: string[] = [];
-          for (let gi = 1; gi <= stakingVaults.length; gi++) {
+          for (let gi = 1; gi <= total; gi++) {
             // vaultHub uses 1-based indexing, but stakingVaults is a regular 0-based JS array.
             const idx = gi - 1;
             const { stakingVault } = stakingVaults[idx];
@@ -456,6 +477,7 @@ describe("VaultViewer", () => {
             }
           }
 
+          // ✅ Address ordering check
           expect(collected).to.deep.equal(expected);
         });
       });

--- a/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
+++ b/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
@@ -1167,38 +1167,38 @@ describe("VaultViewer", () => {
       }
     });
 
-    // const cases = [
-    //   {
-    //     label: "vaultsByOwner",
-    //     args: async (owner: string) => [owner, 1, stakingVaultCount],
-    //   },
-    //   {
-    //     label: "vaultsDataBatch",
-    //     args: () => [1, stakingVaultCount],
-    //   },
-    //   {
-    //     label: "vaultsByRole",
-    //     args: async () => {
-    //       const role = await stakingVaults[0].dashboard.DEFAULT_ADMIN_ROLE();
-    //       return [role, allStakingVaultsOwnerAddr, 1, stakingVaultCount];
-    //     },
-    //   },
-    // ];
+    const cases = [
+      {
+        label: "vaultsByOwnerBatch",
+        args: async (owner: string) => [owner, 1, stakingVaultCount],
+      },
+      {
+        label: "vaultsDataBatch",
+        args: () => [1, stakingVaultCount],
+      },
+      {
+        label: "vaultsByRoleBatch",
+        args: async () => {
+          const role = await stakingVaults[0].dashboard.DEFAULT_ADMIN_ROLE();
+          return [role, allStakingVaultsOwnerAddr, 1, stakingVaultCount];
+        },
+      },
+    ];
 
-    // cases.forEach(({ label, args }) => {
-    //   it(`${label} gas estimation`, async () => {
-    //     const resolvedArgs = typeof args === "function" ? await args(allStakingVaultsOwnerAddr) : args;
-    //
-    //     const gasEstimate = await ethers.provider.estimateGas({
-    //       to: await vaultViewer.getAddress(),
-    //       data: vaultViewer.interface.encodeFunctionData(label, resolvedArgs),
-    //     });
-    //
-    //     console.log(`⛽️ ${label} gas estimate (vaults: ${stakingVaultCount}):`);
-    //     console.log(`   ${formatWithSpaces(gasEstimate)}`);
-    //     expect(gasEstimate).to.lte(gasLimit);
-    //   });
-    // });
+    cases.forEach(({ label, args }) => {
+      it(`${label} gas estimation`, async () => {
+        const resolvedArgs = typeof args === "function" ? await args(allStakingVaultsOwnerAddr) : args;
+
+        const gasEstimate = await ethers.provider.estimateGas({
+          to: await vaultViewer.getAddress(),
+          data: vaultViewer.interface.encodeFunctionData(label, resolvedArgs),
+        });
+
+        console.log(`⛽️ ${label} gas estimate (vaults: ${stakingVaultCount}):`);
+        console.log(`   ${formatWithSpaces(gasEstimate)}`);
+        expect(gasEstimate).to.lte(gasLimit);
+      });
+    });
 
     // role grants here do not affect tests above
     it("roleMembersBatch gas estimation (with role grants)", async () => {

--- a/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
+++ b/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
@@ -255,58 +255,58 @@ describe("VaultViewer", () => {
       }
     });
 
-    [
-      { from: 1, to: 1 },
-      { from: 1, to: 2 },
-      { from: 2, to: 3 },
-      { from: 1, to: stakingVaultCount },
-      { from: 3, to: stakingVaultCount },
-      { from: stakingVaultCount, to: stakingVaultCount },
-      { from: 1, to: stakingVaultCount }, // All
-      { from: 1, to: stakingVaultCount + 1 }, // more that all
-      { from: 1, to: stakingVaultCount + stakingVaultCount }, // more that all
-    ].forEach(({ from, to }) => {
-      it(`returns vault contracts in a given range [${from}, ${to}]`, async () => {
-        const [vaults, leftover] = await vaultViewer.vaultAddressesBound(from, to);
+    // [
+    //   { from: 1, to: 1 },
+    //   { from: 1, to: 2 },
+    //   { from: 2, to: 3 },
+    //   { from: 1, to: stakingVaultCount },
+    //   { from: 3, to: stakingVaultCount },
+    //   { from: stakingVaultCount, to: stakingVaultCount },
+    //   { from: 1, to: stakingVaultCount }, // All
+    //   { from: 1, to: stakingVaultCount + 1 }, // more that all
+    //   { from: 1, to: stakingVaultCount + stakingVaultCount }, // more that all
+    // ].forEach(({ from, to }) => {
+    //   it(`returns vault contracts in a given range [${from}, ${to}]`, async () => {
+    //     const [vaults, leftover] = await vaultViewer.vaultAddressesBound(from, to);
+    //
+    //     const safeTo = Math.min(to, stakingVaultCount);
+    //     const expectedLength = from > safeTo ? 0 : safeTo - from + 1;
+    //     expect(vaults.length).to.equal(expectedLength);
+    //
+    //     const expectedLeftover = Math.max(0, stakingVaultCount - safeTo);
+    //     expect(leftover).to.equal(expectedLeftover);
+    //   });
+    // });
 
-        const safeTo = Math.min(to, stakingVaultCount);
-        const expectedLength = from > safeTo ? 0 : safeTo - from + 1;
-        expect(vaults.length).to.equal(expectedLength);
+    // [
+    //   { from: 1_000, to: 10_000 },
+    //   { from: 3, to: 1 },
+    //   { from: stakingVaultCount, to: 1 },
+    //   { from: stakingVaultCount * 10, to: stakingVaultCount * 10 },
+    //   { from: stakingVaultCount * 10, to: stakingVaultCount * 100 },
+    //   { from: stakingVaultCount * 100, to: stakingVaultCount },
+    // ].forEach(({ from, to }) => {
+    //   it(`reverts if given range is invalid [${from}, ${to}]`, async () => {
+    //     await expect(vaultViewer.vaultAddressesBound(from, to)).to.be.revertedWithCustomError(
+    //       vaultViewer,
+    //       "WrongPaginationRange",
+    //     );
+    //   });
+    // });
 
-        const expectedLeftover = Math.max(0, stakingVaultCount - safeTo);
-        expect(leftover).to.equal(expectedLeftover);
-      });
-    });
-
-    [
-      { from: 1_000, to: 10_000 },
-      { from: 3, to: 1 },
-      { from: stakingVaultCount, to: 1 },
-      { from: stakingVaultCount * 10, to: stakingVaultCount * 10 },
-      { from: stakingVaultCount * 10, to: stakingVaultCount * 100 },
-      { from: stakingVaultCount * 100, to: stakingVaultCount },
-    ].forEach(({ from, to }) => {
-      it(`reverts if given range is invalid [${from}, ${to}]`, async () => {
-        await expect(vaultViewer.vaultAddressesBound(from, to)).to.be.revertedWithCustomError(
-          vaultViewer,
-          "WrongPaginationRange",
-        );
-      });
-    });
-
-    [
-      { from: 0, to: 0 },
-      { from: 0, to: 1 },
-      { from: 0, to: 2 },
-      { from: stakingVaultCount, to: 0 },
-    ].forEach(({ from, to }) => {
-      it(`reverts with ZeroArgument for invalid range [${from}, ${to}]`, async () => {
-        await expect(vaultViewer.vaultAddressesBound(from, to)).to.be.revertedWithCustomError(
-          vaultViewer,
-          "ZeroArgument",
-        );
-      });
-    });
+    //   [
+    //     { from: 0, to: 0 },
+    //     { from: 0, to: 1 },
+    //     { from: 0, to: 2 },
+    //     { from: stakingVaultCount, to: 0 },
+    //   ].forEach(({ from, to }) => {
+    //     it(`reverts with ZeroArgument for invalid range [${from}, ${to}]`, async () => {
+    //       await expect(vaultViewer.vaultAddressesBound(from, to)).to.be.revertedWithCustomError(
+    //         vaultViewer,
+    //         "ZeroArgument",
+    //       );
+    //     });
+    //   });
   });
 
   context("vaults by owner", () => {
@@ -749,32 +749,33 @@ describe("VaultViewer", () => {
     });
 
     [
-      { from: 1, to: 1 },
-      { from: 1, to: 2 },
-      { from: 2, to: 3 },
-      { from: 1, to: stakingVaultCount },
-      { from: 3, to: stakingVaultCount },
-      { from: stakingVaultCount, to: stakingVaultCount },
-      { from: 1, to: stakingVaultCount }, // All
-      { from: 1, to: stakingVaultCount + 1 }, // more that all
-      { from: 1, to: stakingVaultCount + stakingVaultCount }, // more that all
-    ].forEach(({ from, to }) => {
-      it(`returns data for a batch of vaults with vaultsDataBound [${from}, ${to}]`, async () => {
+      { offset: 0, limit: 1 },
+      { offset: 0, limit: 2 },
+      { offset: 1, limit: 2 },
+      // all
+      { offset: 0, limit: stakingVaultCount },
+      { offset: 2, limit: stakingVaultCount },
+      // only last
+      { offset: stakingVaultCount - 1, limit: stakingVaultCount },
+      { offset: 0, limit: stakingVaultCount + 1 },
+      { offset: 0, limit: stakingVaultCount * 2 },
+      // empty
+      { offset: stakingVaultCount, limit: 10 },
+      // empty
+      { offset: stakingVaultCount + 5, limit: 10 },
+    ].forEach(({ offset, limit }) => {
+      it(`returns data for a batch of vaults with vaultsDataBound(offset=${offset}, limit=${limit})`, async () => {
         const totalVaults = stakingVaults.length;
+        const vaultsData = await vaultViewer.vaultsDataBound(offset, limit);
 
-        // 1-based inclusive
-        const safeTo = Math.min(to, totalVaults);
-        const expectedLength = safeTo >= from ? safeTo - from + 1 : 0;
-        const expectedLeftover = totalVaults > safeTo ? totalVaults - safeTo : 0;
-
-        const { vaultsData, leftover } = await vaultViewer.vaultsDataBound(from, to);
-
+        // ✅ Length check
+        const expectedLength = offset >= totalVaults ? 0 : Math.min(limit, totalVaults - offset);
         expect(vaultsData.length).to.equal(expectedLength);
-        expect(leftover).to.equal(expectedLeftover);
 
         for (let i = 0; i < vaultsData.length; i++) {
+          // ✅ Address ordering check
           // vaultHub uses 1-based indexing, but stakingVaults is a regular 0-based JS array.
-          expect(vaultsData[i].vaultAddress).to.equal(await stakingVaults[from - 1 + i].stakingVault.getAddress());
+          expect(vaultsData[i].vaultAddress).to.equal(await stakingVaults[offset + i].stakingVault.getAddress());
 
           // ✅ Sanity check: values are returned and types match
           expect(vaultsData[i].connection.forcedRebalanceThresholdBP).to.be.a("bigint");
@@ -818,80 +819,93 @@ describe("VaultViewer", () => {
     });
 
     [
-      { from: 1, pageSize: 1 },
-      { from: 1, pageSize: 2 },
-      { from: 2, pageSize: 2 },
-      { from: 1, pageSize: 3 },
-      { from: 2, pageSize: 3 },
-      { from: 1, pageSize: stakingVaultCount }, // all
-      { from: 2, pageSize: stakingVaultCount }, // all
-      { from: 1, pageSize: stakingVaultCount + stakingVaultCount }, // more than all
-      { from: 2, pageSize: stakingVaultCount + stakingVaultCount }, // more than all
-    ].forEach(({ from, pageSize }) => {
-      it(`walks all pages with vaultsDataBound(from=${from}, pageSize=${pageSize}) and returns vaults in order`, async () => {
+      { startOffset: 0, pageSize: 1 },
+      { startOffset: 0, pageSize: 2 },
+      { startOffset: 0, pageSize: 3 },
+      { startOffset: 1, pageSize: 1 },
+      { startOffset: 1, pageSize: 2 },
+      { startOffset: 1, pageSize: 3 },
+      // all
+      { startOffset: 0, pageSize: stakingVaultCount },
+      { startOffset: 0, pageSize: stakingVaultCount / 2 },
+      { startOffset: 0, pageSize: stakingVaultCount / 3 },
+      { startOffset: 1, pageSize: stakingVaultCount },
+      { startOffset: 1, pageSize: stakingVaultCount / 2 },
+      { startOffset: 1, pageSize: stakingVaultCount / 3 },
+      { startOffset: 0, pageSize: stakingVaultCount + stakingVaultCount },
+      { startOffset: 1, pageSize: stakingVaultCount + stakingVaultCount },
+      // /all
+      // only last
+      { startOffset: stakingVaultCount - 1, pageSize: stakingVaultCount },
+      { startOffset: stakingVaultCount - 1, pageSize: 1 },
+      { startOffset: stakingVaultCount - 1, pageSize: 2 },
+      { startOffset: stakingVaultCount - 1, pageSize: 3 },
+      // /only last
+      // empty
+      { startOffset: stakingVaultCount, pageSize: 1 },
+      { startOffset: stakingVaultCount, pageSize: stakingVaultCount },
+      // /empty
+    ].forEach(({ startOffset, pageSize }) => {
+      it(`walks pages with vaultsDataBound(offset=${startOffset}, limit=${pageSize}) and preserves order`, async () => {
         const collected: string[] = [];
-        const totalVaults = stakingVaults.length;
+        const total = stakingVaults.length;
 
-        let curFrom = from;
-        let curTo = curFrom + pageSize - 1;
+        let offset = startOffset;
+        // safe
+        const maxPages = Math.ceil(Math.max(0, total - startOffset) / Math.max(1, pageSize)) + 2;
 
-        const remaining = Math.max(0, totalVaults - (curFrom - 1));
-        const maxPages = Math.ceil(remaining / pageSize) + 1;
         for (let page = 0; page < maxPages; page++) {
-          const { vaultsData, leftover } = await vaultViewer.vaultsDataBound(curFrom, curTo);
+          const batch = await vaultViewer.vaultsDataBound(offset, pageSize);
 
-          const safeTo = Math.min(curTo, totalVaults);
-          const expectedLength = safeTo >= curFrom ? safeTo - curFrom + 1 : 0;
-          expect(vaultsData.length).to.equal(expectedLength);
+          // ✅ Length check
+          const expectedSize = offset >= total ? 0 : Math.min(pageSize, total - offset);
+          expect(batch.length).to.equal(expectedSize);
 
-          // leftover = vaultsCount - safeTo
-          const expectedLeftover = BigInt(totalVaults - safeTo);
-          expect(leftover).to.equal(expectedLeftover);
-
-          for (let i = 0; i < vaultsData.length; i++) {
-            const expectedAddr = await stakingVaults[curFrom - 1 + i].stakingVault.getAddress();
-            expect(vaultsData[i].vaultAddress).to.equal(expectedAddr);
-            collected.push(vaultsData[i].vaultAddress);
+          for (let i = 0; i < batch.length; i++) {
+            // ✅ Address ordering check
+            // vaultHub uses 1-based indexing, but stakingVaults is a regular 0-based JS array.
+            expect(batch[i].vaultAddress).to.equal(await stakingVaults[offset + i].stakingVault.getAddress());
+            collected.push(batch[i].vaultAddress);
           }
 
-          if (leftover === 0n) break;
+          // last page
+          if (batch.length < pageSize) break;
 
-          // next page
-          curFrom = curTo + 1;
-          curTo = curFrom + pageSize - 1;
+          offset += batch.length;
         }
 
+        // ✅ Address ordering check
         const expectedAll = await Promise.all(
-          stakingVaults.slice(from - 1).map(({ stakingVault }) => stakingVault.getAddress()),
+          stakingVaults.slice(startOffset).map(({ stakingVault }) => stakingVault.getAddress()),
         );
-
         expect(collected).to.deep.equal(expectedAll);
       });
     });
 
     [
-      { from: stakingVaultCount + 1, to: stakingVaultCount * 10 },
-      { from: stakingVaultCount * 10, to: stakingVaultCount * 10 },
-      { from: stakingVaultCount * 100, to: stakingVaultCount * 10 },
-      { from: stakingVaultCount * 10, to: stakingVaultCount * 100 },
-    ].forEach(({ from, to }) => {
-      it(`reverts with WrongPaginationRange for invalid range [${from}, ${to}]`, async () => {
-        await expect(vaultViewer.vaultsDataBound(from, to)).to.be.revertedWithCustomError(
-          vaultViewer,
-          "WrongPaginationRange",
-        );
+      { offset: stakingVaultCount + 1, limit: stakingVaultCount * 10 },
+      { offset: stakingVaultCount * 10, limit: stakingVaultCount * 10 },
+      { offset: stakingVaultCount * 100, limit: stakingVaultCount * 10 },
+      { offset: stakingVaultCount * 10, limit: stakingVaultCount * 100 },
+    ].forEach(({ offset, limit }) => {
+      it(`returns empty array for out-of-range (offset=${offset}, limit=${limit})`, async () => {
+        const result = await vaultViewer.vaultsDataBound(offset, limit);
+        expect(result.length).to.equal(0);
       });
     });
-  });
 
-  [
-    { from: 0, to: 0 },
-    { from: 0, to: 1 },
-    { from: 0, to: 2 },
-    { from: stakingVaultCount, to: 0 },
-  ].forEach(({ from, to }) => {
-    it(`reverts with ZeroArgument for invalid range [${from}, ${to}]`, async () => {
-      await expect(vaultViewer.vaultsDataBound(from, to)).to.be.revertedWithCustomError(vaultViewer, "ZeroArgument");
+    [
+      { offset: 0, limit: 0 },
+      { offset: 1, limit: 0 },
+      { offset: stakingVaultCount, limit: 0 },
+      { offset: stakingVaultCount * 10, limit: 0 },
+    ].forEach(({ offset, limit }) => {
+      it(`reverts with ZeroArgument when limit == 0 [${offset}, ${limit}]`, async () => {
+        await expect(vaultViewer.vaultsDataBound(offset, limit)).to.be.revertedWithCustomError(
+          vaultViewer,
+          "ZeroArgument",
+        );
+      });
     });
   });
 
@@ -1114,38 +1128,38 @@ describe("VaultViewer", () => {
       }
     });
 
-    const cases = [
-      {
-        label: "vaultsByOwner",
-        args: async (owner: string) => [owner, 1, stakingVaultCount],
-      },
-      {
-        label: "vaultsDataBound",
-        args: () => [1, stakingVaultCount],
-      },
-      {
-        label: "vaultsByRole",
-        args: async () => {
-          const role = await stakingVaults[0].dashboard.DEFAULT_ADMIN_ROLE();
-          return [role, allStakingVaultsOwnerAddr, 1, stakingVaultCount];
-        },
-      },
-    ];
+    // const cases = [
+    //   {
+    //     label: "vaultsByOwner",
+    //     args: async (owner: string) => [owner, 1, stakingVaultCount],
+    //   },
+    //   {
+    //     label: "vaultsDataBound",
+    //     args: () => [1, stakingVaultCount],
+    //   },
+    //   {
+    //     label: "vaultsByRole",
+    //     args: async () => {
+    //       const role = await stakingVaults[0].dashboard.DEFAULT_ADMIN_ROLE();
+    //       return [role, allStakingVaultsOwnerAddr, 1, stakingVaultCount];
+    //     },
+    //   },
+    // ];
 
-    cases.forEach(({ label, args }) => {
-      it(`${label} gas estimation`, async () => {
-        const resolvedArgs = typeof args === "function" ? await args(allStakingVaultsOwnerAddr) : args;
-
-        const gasEstimate = await ethers.provider.estimateGas({
-          to: await vaultViewer.getAddress(),
-          data: vaultViewer.interface.encodeFunctionData(label, resolvedArgs),
-        });
-
-        console.log(`⛽️ ${label} gas estimate (vaults: ${stakingVaultCount}):`);
-        console.log(`   ${formatWithSpaces(gasEstimate)}`);
-        expect(gasEstimate).to.lte(gasLimit);
-      });
-    });
+    // cases.forEach(({ label, args }) => {
+    //   it(`${label} gas estimation`, async () => {
+    //     const resolvedArgs = typeof args === "function" ? await args(allStakingVaultsOwnerAddr) : args;
+    //
+    //     const gasEstimate = await ethers.provider.estimateGas({
+    //       to: await vaultViewer.getAddress(),
+    //       data: vaultViewer.interface.encodeFunctionData(label, resolvedArgs),
+    //     });
+    //
+    //     console.log(`⛽️ ${label} gas estimate (vaults: ${stakingVaultCount}):`);
+    //     console.log(`   ${formatWithSpaces(gasEstimate)}`);
+    //     expect(gasEstimate).to.lte(gasLimit);
+    //   });
+    // });
 
     // role grants here do not affect tests above
     it("roleMembersBatch gas estimation (with role grants)", async () => {

--- a/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
+++ b/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
@@ -770,9 +770,9 @@ describe("VaultViewer", () => {
       // empty
       { offset: stakingVaultCount + 5, limit: 10 },
     ].forEach(({ offset, limit }) => {
-      it(`returns data for a batch of vaults with vaultsDataBound(offset=${offset}, limit=${limit})`, async () => {
+      it(`returns data for a batch of vaults with vaultsDataBatch(offset=${offset}, limit=${limit})`, async () => {
         const totalVaults = stakingVaults.length;
-        const vaultsData = await vaultViewer.vaultsDataBound(offset, limit);
+        const vaultsData = await vaultViewer.vaultsDataBatch(offset, limit);
 
         // ✅ Length check
         const expectedLength = offset >= totalVaults ? 0 : Math.min(limit, totalVaults - offset);
@@ -852,7 +852,7 @@ describe("VaultViewer", () => {
       { startOffset: stakingVaultCount, pageSize: stakingVaultCount },
       // /empty
     ].forEach(({ startOffset, pageSize }) => {
-      it(`walks pages with vaultsDataBound(offset=${startOffset}, limit=${pageSize}) and preserves order`, async () => {
+      it(`walks pages with vaultsDataBatch(offset=${startOffset}, limit=${pageSize}) and preserves order`, async () => {
         const collected: string[] = [];
         const total = stakingVaults.length;
 
@@ -861,7 +861,7 @@ describe("VaultViewer", () => {
         const maxPages = Math.ceil(Math.max(0, total - startOffset) / Math.max(1, pageSize)) + 2;
 
         for (let page = 0; page < maxPages; page++) {
-          const batch = await vaultViewer.vaultsDataBound(offset, pageSize);
+          const batch = await vaultViewer.vaultsDataBatch(offset, pageSize);
 
           // ✅ Length check
           const expectedSize = offset >= total ? 0 : Math.min(pageSize, total - offset);
@@ -898,7 +898,7 @@ describe("VaultViewer", () => {
       { offset: stakingVaultCount * 10, limit: stakingVaultCount * 100 },
     ].forEach(({ offset, limit }) => {
       it(`returns empty array for out-of-range (offset=${offset}, limit=${limit})`, async () => {
-        const result = await vaultViewer.vaultsDataBound(offset, limit);
+        const result = await vaultViewer.vaultsDataBatch(offset, limit);
         expect(result.length).to.equal(0);
       });
     });
@@ -910,7 +910,7 @@ describe("VaultViewer", () => {
       { offset: stakingVaultCount * 10, limit: 0 },
     ].forEach(({ offset, limit }) => {
       it(`reverts with ZeroArgument when limit == 0 [${offset}, ${limit}]`, async () => {
-        await expect(vaultViewer.vaultsDataBound(offset, limit)).to.be.revertedWithCustomError(
+        await expect(vaultViewer.vaultsDataBatch(offset, limit)).to.be.revertedWithCustomError(
           vaultViewer,
           "ZeroArgument",
         );
@@ -1143,7 +1143,7 @@ describe("VaultViewer", () => {
     //     args: async (owner: string) => [owner, 1, stakingVaultCount],
     //   },
     //   {
-    //     label: "vaultsDataBound",
+    //     label: "vaultsDataBatch",
     //     args: () => [1, stakingVaultCount],
     //   },
     //   {

--- a/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
+++ b/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
@@ -513,101 +513,108 @@ describe("VaultViewer", () => {
       { label: "granteeWithNoRoles", getGrantee: () => granteeWithNoRoles },
     ];
 
-    const successRanges = [
-      { cursor: 1, limit: 1 },
-      { cursor: 1, limit: 2 },
-      { cursor: 3, limit: 6 },
-      { cursor: vaultSplitIndex, limit: vaultSplitIndex },
+    const successBatches = [
+      { offset: 0, limit: 1 },
+      { offset: 0, limit: 2 },
+      { offset: 2, limit: 6 },
+      { offset: vaultSplitIndex - 1, limit: vaultSplitIndex },
     ];
 
     granteesTestCases.forEach(({ label, getGrantee }) => {
-      successRanges.forEach(({ cursor, limit }) => {
-        it(`returns vaults for ${label} where cursor=${cursor}, limit=${limit}`, async () => {
+      successBatches.forEach(({ offset, limit }) => {
+        it(`returns vaults for ${label} where offset=${offset}, limit=${limit}`, async () => {
           const grantee = getGrantee();
           const granteeAddr = await grantee.getAddress();
           const role = await stakingVaults[0].dashboard.DEFAULT_ADMIN_ROLE();
 
-          const [vaults, nextCursor] = await vaultViewer.vaultsByRole(role, granteeAddr, cursor, limit);
+          const vaults = await vaultViewer.vaultsByRoleBatch(role, granteeAddr, offset, limit);
 
           const total = stakingVaults.length;
-          const remaining = total - cursor + 1;
-          const scan = Math.min(limit, Math.max(remaining, 0));
+          const endExclusive = Math.min(offset + limit, total);
 
-          let expectedCount = 0;
-          for (let gi = cursor; gi <= total && gi < cursor + scan; gi++) {
-            // vaultHub uses 1-based indexing, but stakingVaults is a regular 0-based JS array.
-            const idx = gi - 1;
+          const expected: string[] = [];
+          for (let idx = offset; idx < endExclusive; idx++) {
+            const { stakingVault } = stakingVaults[idx];
             const grantedTo = idx < vaultSplitIndex ? firstBatchGrantee : secondBatchGrantee;
             const grantedAddr = await grantedTo.getAddress();
-            if (granteeAddr === grantedAddr) expectedCount++;
+            if (granteeAddr === grantedAddr) {
+              expected.push(await stakingVault.getAddress());
+            }
           }
 
           // ✅ Check vaults count
-          expect(vaults.length).to.equal(expectedCount);
+          expect(vaults.length).to.equal(expected.length);
 
-          // ✅ Check nextCursor
-          const expectedNextCursor = cursor + scan <= total ? BigInt(cursor + scan) : 0n;
-          expect(nextCursor).to.equal(expectedNextCursor);
+          // ✅ Address ordering check
+          expect(vaults).to.deep.equal(expected);
         });
       });
     });
 
     granteesTestCases.forEach(({ label, getGrantee }) => {
       const failedRanges = [
-        { cursor: 0, limit: 0 },
-        { cursor: 0, limit: 3 },
-        { cursor: 0, limit: vaultSplitIndex },
-        { cursor: 0, limit: vaultSplitIndex * 10 },
+        { offset: 0, limit: 0 },
+        { offset: 1, limit: 0 },
+        { offset: vaultSplitIndex, limit: 0 },
+        { offset: stakingVaultCount, limit: 0 },
       ];
 
-      failedRanges.forEach(({ cursor, limit }) => {
-        it(`reverts with ZeroArgument for ${label} where cursor=${cursor}, limit=${limit}`, async () => {
+      failedRanges.forEach(({ offset, limit }) => {
+        it(`reverts with ZeroArgument for ${label} where offset=${offset}, limit=${limit}`, async () => {
           const grantee = getGrantee();
+          const granteeAddr = await grantee.getAddress();
           const role = await stakingVaults[0].dashboard.DEFAULT_ADMIN_ROLE();
-          await expect(
-            vaultViewer.vaultsByRole(role, grantee.getAddress(), cursor, limit),
-          ).to.be.revertedWithCustomError(vaultViewer, "ZeroArgument");
+
+          await expect(vaultViewer.vaultsByRoleBatch(role, granteeAddr, offset, limit)).to.be.revertedWithCustomError(
+            vaultViewer,
+            "ZeroArgument",
+          );
         });
       });
     });
 
     granteesTestCases.forEach(({ label, getGrantee }) => {
-      const failedRanges = [
-        { cursor: stakingVaultCount + 1, limit: 2 },
-        { cursor: stakingVaultCount * 10, limit: stakingVaultCount * 10 },
+      const outOfRangeCases = [
+        { offset: stakingVaultCount, limit: 2 },
+        { offset: stakingVaultCount + 1, limit: 2 },
+        { offset: stakingVaultCount * 10, limit: stakingVaultCount * 10 },
       ];
 
-      failedRanges.forEach(({ cursor, limit }) => {
-        it(`reverts with WrongCursorPagination for ${label} where cursor=${cursor}, limit=${limit}`, async () => {
+      outOfRangeCases.forEach(({ offset, limit }) => {
+        it(`returns empty array for ${label} where offset=${offset}, limit=${limit}`, async () => {
           const grantee = getGrantee();
+          const granteeAddr = await grantee.getAddress();
           const role = await stakingVaults[0].dashboard.DEFAULT_ADMIN_ROLE();
-          await expect(
-            vaultViewer.vaultsByRole(role, grantee.getAddress(), cursor, limit),
-          ).to.be.revertedWithCustomError(vaultViewer, "WrongCursorPagination");
+
+          const vaults = await vaultViewer.vaultsByRoleBatch(role, granteeAddr, offset, limit);
+
+          // ✅ Check vaults count
+          expect(vaults.length).to.equal(0);
         });
       });
     });
 
     granteesTestCases.forEach(({ label, getGrantee }) => {
       [
-        { cursor: 1, limit: 1 },
-        { cursor: 1, limit: 2 },
-        { cursor: 1, limit: 3 },
-        { cursor: 1, limit: stakingVaultCount },
-      ].forEach(({ cursor, limit }) => {
-        it(`walks all pages(cursor=${cursor}, limit=${limit}) for ${label} via nextCursor and returns exactly matching vaults in order`, async () => {
+        { offset: 0, limit: 1 },
+        { offset: 0, limit: 2 },
+        { offset: 0, limit: 3 },
+        { offset: 0, limit: stakingVaultCount },
+      ].forEach(({ offset, limit }) => {
+        it(`walks all pages(offset=${offset}, limit=${limit}) for ${label} and returns exactly matching vaults in order`, async () => {
           const maxIters = 100;
           const collected: string[] = [];
 
           const grantee = getGrantee();
           const role = await stakingVaults[0].dashboard.DEFAULT_ADMIN_ROLE();
 
-          for (let i = 0; i < maxIters; i++) {
-            const [page, nextCursor] = await vaultViewer.vaultsByRole(role, grantee, cursor, limit);
+          let curOffset = offset;
+          for (let i = 0; i < maxIters && curOffset < stakingVaults.length; i++) {
+            const page: string[] = await vaultViewer.vaultsByRoleBatch(role, grantee, curOffset, limit);
+
             collected.push(...page);
 
-            if (nextCursor === 0n) break;
-            cursor = Number(nextCursor);
+            curOffset += limit;
           }
 
           const expected: string[] = [];
@@ -621,6 +628,7 @@ describe("VaultViewer", () => {
             }
           }
 
+          // ✅ Address ordering check
           expect(collected).to.deep.equal(expected);
         });
       });

--- a/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
+++ b/test/mocha/0.8.25/vaults/vault-viewer/VaultViewer.test.ts
@@ -275,7 +275,7 @@ describe("VaultViewer", () => {
         const total = stakingVaultCount;
         const expectedLength = offset >= total ? 0 : Math.min(limit, total - offset);
 
-        const vaults = await vaultViewer.vaultAddressesBound(offset, limit);
+        const vaults = await vaultViewer.vaultAddressesBatch(offset, limit);
         expect(vaults.length).to.equal(expectedLength);
 
         for (let i = 0; i < vaults.length; i++) {
@@ -295,7 +295,7 @@ describe("VaultViewer", () => {
       { offset: stakingVaultCount * 10, limit: stakingVaultCount * 100 },
     ].forEach(({ offset, limit }) => {
       it(`returns empty for out-of-range (offset=${offset}, limit=${limit})`, async () => {
-        const vaults = await vaultViewer.vaultAddressesBound(offset, limit);
+        const vaults = await vaultViewer.vaultAddressesBatch(offset, limit);
         expect(vaults.length).to.equal(0);
       });
     });
@@ -307,7 +307,7 @@ describe("VaultViewer", () => {
       { offset: stakingVaultCount * 10, limit: 0 },
     ].forEach(({ offset, limit }) => {
       it(`reverts with ZeroArgument when limit is zero (offset=${offset}, limit=${limit})`, async () => {
-        await expect(vaultViewer.vaultAddressesBound(offset, limit)).to.be.revertedWithCustomError(
+        await expect(vaultViewer.vaultAddressesBatch(offset, limit)).to.be.revertedWithCustomError(
           vaultViewer,
           "ZeroArgument",
         );


### PR DESCRIPTION
### Description

Renaming:
- `vaultsByOwner` --> `vaultsByOwnerBatch`
- `vaultsByRole` --> `vaultsByRoleBatch`
- `vaultsDataBound` --> `vaultsDataBatch`
- `vaultAddressesBound` --> `vaultAddressesBatch`

Made `_offset, _limit` pagination for:
- `vaultsByOwnerBatch`
- `vaultsByRoleBatch`
- `vaultsDataBatch`
- `vaultAddressesBatch`

like here https://github.com/lidofinance/core/blob/feat/vaults/contracts/0.8.25/vaults/LazyOracle.sol#L243 

Update tests and docs.

### Demo
https://hoodi.etherscan.io/address/0xBa9a3127f053a6548FE3874326569E1821783e03


### Checklist:

- [x] Checked the changes locally.
- [ ] Created/updated unit tests.
- [ ] Created/updated README.md.
